### PR TITLE
Fix typo; Add datatables js/css info in intro section

### DIFF
--- a/en/jquery/web/docs/tables/datatables/o.html
+++ b/en/jquery/web/docs/tables/datatables/o.html
@@ -321,6 +321,28 @@
       <strong>4.5.7</strong> (released 16.07.2018).</p>
   </blockquote>
 
+    <p>
+    To use DataTables, you have to include the path to DataTable, then select CSS and JavaScript. The files are located in the
+    <code>addons</code>
+    folder.
+  </p>
+
+  <!--Section: Code-->
+  <section>
+    <mdbsnippet>
+
+      <code data-lang="html" data-name="HTML">
+
+        <!-- DataTables CSS -->
+        <link href="css/addons/datatables.min.css" rel="stylesheet">
+        <!-- DataTables JS -->
+        <script href="js/addons/datatables.min.js" rel="stylesheet"></script>
+
+      </code>
+
+    </mdbsnippet>
+  </section>
+  <!--Section: Code-->
 
 </section>
 <!--/Section: Intro-->
@@ -839,7 +861,7 @@
   <!--Section: Live preview-->
 
   <p>To use DataTables call
-    <code>$().DataTables()</code> method on the table. An example is given in the <strong>"JavaScript"</strong> tab in
+    <code>$().DataTable()</code> method on the table. An example is given in the <strong>"JavaScript"</strong> tab in
     the code below.</p>
 
   <!--Section: Code-->


### PR DESCRIPTION
The indication about (datables) js/css loading from addons is not obvious for newcomers. The relevant information from section `select` was copied to intro.