### PR TITLE
Add  "light" to Navbar Properties

### DIFF
--- a/en/react/web/docs/navigation/navbars/a.html
+++ b/en/react/web/docs/navigation/navbars/a.html
@@ -82,6 +82,13 @@
         <td>Change navbar's theme to dark (text color will be white)</td>
         <td><code class="language-markup">&lt;MDBNavbar dark /&gt;</code></td>
       </tr>
+       <tr>
+        <td><code class="word-break: normal">light</code></td>
+        <td><i>Boolean</i></td>
+        <td><code style="word-break: normal">false</code></td>
+        <td>Change navbar's theme to light (text color will be black)</td>
+        <td><code class="language-markup">&lt;MDBNavbar ligth /&gt;</code></td>
+      </tr>
       <tr>
         <td><code class="word-break: normal">double</code></td>
         <td><i>Boolean</i></td>


### PR DESCRIPTION
In "Navbar Properties", the propertie `dark` is defined but not `light`. So it's just an update to add this one