### PR TITLE
Explicitly mention HammerJs dependency on carousel for mobile devices.

### DIFF
--- a/en/angular/web/docs/advanced/carousel/o-ss.html
+++ b/en/angular/web/docs/advanced/carousel/o-ss.html
@@ -14,3 +14,4 @@
     <li class="nav-item"><a class="nav-link" href="#full-page-video-carousel">Full page video carousel</a></li>
   </ul>
 </li>
+<li class="nav-item"><a class="nav-link" href="#mobile-devices">Full page video carousel</a></li>

--- a/en/angular/web/docs/advanced/carousel/o-ss.html
+++ b/en/angular/web/docs/advanced/carousel/o-ss.html
@@ -14,4 +14,4 @@
     <li class="nav-item"><a class="nav-link" href="#full-page-video-carousel">Full page video carousel</a></li>
   </ul>
 </li>
-<li class="nav-item"><a class="nav-link" href="#mobile-devices">Full page video carousel</a></li>
+<li class="nav-item"><a class="nav-link" href="#mobile-devices">Mobile devices</a></li>

--- a/en/angular/web/docs/advanced/carousel/o.html
+++ b/en/angular/web/docs/advanced/carousel/o.html
@@ -1371,3 +1371,21 @@
 
 </section>
 <!--/Section: -->
+  
+<!--Section: -->
+<section id="mobile-devices">
+
+  <!--Title-->
+  <h2 class="section-heading mb-4">
+    Mobile devices
+  </h2>
+
+  <!-- Description -->
+  <p>When using <code>mdb-carousel</code> on devices with touch input you need to configure <code>hammerjs</code>
+    as shown on the <a href="https://mdbootstrap.com/docs/angular/advanced/mobile/"> mobile setup docs.</a> 
+    Otherwise you won't be able to scroll over <code>mdb-carousel</code></p>
+
+</section>
+<!--/Section: -->
+
+<hr class="mt-4 mb-5">


### PR DESCRIPTION
This dependency should be made explicit in order to avoid not being able to scroll over carousels. As this is something that new users can easily miss.