### PR TITLE
Fix typo in table pagination docs

### DIFF
--- a/en/react/web/docs/tables/pagination/o.html
+++ b/en/react/web/docs/tables/pagination/o.html
@@ -1174,7 +1174,7 @@
       <code data-lang="js" data-name="JSX">
 
         <MDBDataTable
-          pagination={false}
+          paging={false}
           data={data}
         />
 


### PR DESCRIPTION
Pagination is disabled via the prop `paging={false}`, not `pagination={false}`