### PR TITLE
Correct Example for Injecting Data Into the Modal

### DIFF
--- a/en/angular/web/docs/modals/basic/o.html
+++ b/en/angular/web/docs/modals/basic/o.html
@@ -1175,7 +1175,7 @@ export class AppComponent {
   }
 
   openModal() {
-    this.modalRef = this.modalService.show(ModalComponent, { this.modalOptions });
+    this.modalRef = this.modalService.show(ModalComponent, this.modalOptions);
   }
 }
         </code>


### PR DESCRIPTION
Fixed data type error that prevented modal options from being properly used by the documented example.