### PR TITLE
[Doc-React] Update DropdownToggle default tag

### DIFF
--- a/en/react/web/docs/components/dropdowns/a.html
+++ b/en/react/web/docs/components/dropdowns/a.html
@@ -175,7 +175,7 @@
           <tr>
             <td class="text-nowrap"><code class="highlighter-rouge">tag</code></td>
             <td><i>String</i></td>
-            <td><code>div</code></td>
+            <td><code>button</code></td>
             <td>Changes dropdown's wrapper tag</td>
             <td><code class="language-markup text-nowrap">&lt;MDBDropdownToggle tag="p" /&gt;</code></td>
           </tr>


### PR DESCRIPTION
Default tag is `button`, in documentation, instead of `div` in reality