### PR TITLE
[Doc-React] Update CardText default tag

### DIFF
--- a/en/react/web/docs/components/cards/a.html
+++ b/en/react/web/docs/components/cards/a.html
@@ -457,7 +457,7 @@
       <tr>
         <td><code class="highlighter-rouge">tag</code></td>
         <td><i>String</i></td>
-        <td><code>img</code></td>
+        <td><code>p</code></td>
         <td>Changes the default html tag for component</td>
         <td><code class="language-markup">&lt;MDBCardText tag=&quot;div&quot; /&gt;</code></td>
       </tr>


### PR DESCRIPTION
Default tag is `img`, in documentation, instead of `p` in reality